### PR TITLE
Add copy support to unmodifiable & synchronized collections

### DIFF
--- a/src/main/java/de/javakaffee/kryoserializers/SynchronizedCollectionsSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/SynchronizedCollectionsSerializer.java
@@ -86,6 +86,20 @@ public class SynchronizedCollectionsSerializer extends Serializer<Object> {
             throw new RuntimeException( e );
         }
     }
+    
+    @Override
+    public Object copy(Kryo kryo, Object original) {
+      try {
+          final SynchronizedCollection collection = SynchronizedCollection.valueOfType( original.getClass() );
+          Object sourceCollectionCopy = kryo.copy(collection.sourceCollectionField.get(original));
+          return collection.create( sourceCollectionCopy );
+      } catch ( final RuntimeException e ) {
+          // Don't eat and wrap RuntimeExceptions
+          throw e;
+      } catch ( final Exception e ) {
+          throw new RuntimeException( e );
+      }
+    }
 
     private static enum SynchronizedCollection {
         COLLECTION( Collections.synchronizedCollection( Arrays.asList( "" ) ).getClass(), SOURCE_COLLECTION_FIELD ){

--- a/src/main/java/de/javakaffee/kryoserializers/UnmodifiableCollectionsSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/UnmodifiableCollectionsSerializer.java
@@ -87,6 +87,20 @@ public class UnmodifiableCollectionsSerializer extends Serializer<Object> {
             throw new RuntimeException( e );
         }
     }
+    
+    @Override
+    public Object copy(Kryo kryo, Object original) {
+      try {
+          final UnmodifiableCollection unmodifiableCollection = UnmodifiableCollection.valueOfType( original.getClass() );
+          Object sourceCollectionCopy = kryo.copy(unmodifiableCollection.sourceCollectionField.get(original));
+          return unmodifiableCollection.create( sourceCollectionCopy );
+      } catch ( final RuntimeException e ) {
+          // Don't eat and wrap RuntimeExceptions
+          throw e;
+      } catch ( final Exception e ) {
+          throw new RuntimeException( e );
+      }
+    }
 
     private static enum UnmodifiableCollection {
         COLLECTION( Collections.unmodifiableCollection( Arrays.asList( "" ) ).getClass(), SOURCE_COLLECTION_FIELD ){

--- a/src/test/java/de/javakaffee/kryoserializers/KryoTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/KryoTest.java
@@ -336,6 +336,24 @@ public class KryoTest {
         assertDeepEquals( deserialized, unmodifiableMap );
     }
     
+    @Test( enabled = true , dataProvider = "unmodifiableCollections" )
+    public void testCopyJavaUtilCollectionsUnmodifiable( Object collection ) throws Exception {
+        final Holder<Object> unmodifiableCollection = new Holder<Object>( collection );
+        final Holder<Object> copy = _kryo.copy( unmodifiableCollection );
+        assertDeepEquals( copy, unmodifiableCollection );
+    }
+    
+    @DataProvider
+    public Object[][] unmodifiableCollections() {
+        final HashMap<String, String> m = new HashMap<String, String>();
+        m.put( "foo", "bar" );
+        return new Object[][] {
+            { Collections.unmodifiableList( new ArrayList<String>( Arrays.asList( "foo", "bar" ) ) ) },
+            { Collections.unmodifiableSet( new HashSet<String>( Arrays.asList( "foo", "bar" ) ) ) },
+            { Collections.unmodifiableMap( m ) },
+        };
+    }
+    
     @SuppressWarnings( "unchecked" )
     @Test( enabled = true )
     public void testJavaUtilCollectionsSynchronizedList() throws Exception {
@@ -360,6 +378,24 @@ public class KryoTest {
         final Map<String, String> map = Collections.synchronizedMap( m );
         final Map<String, String> deserialized = deserialize( serialize( map ), map.getClass() );
         assertDeepEquals( deserialized, map );
+    }
+    
+    @Test( enabled = true , dataProvider = "synchronizedCollections" )
+    public void testCopyJavaUtilCollectionsSynchronizedList( Object collection ) throws Exception {
+        final Holder<Object> synchronizedCollection = new Holder<Object>( collection );
+        final Holder<Object> copy = _kryo.copy( synchronizedCollection );
+        assertDeepEquals( copy, synchronizedCollection );
+    }
+    
+    @DataProvider
+    public Object[][] synchronizedCollections() {
+        final HashMap<String, String> m = new HashMap<String, String>();
+        m.put( "foo", "bar" );
+        return new Object[][] {
+            { Collections.synchronizedList( new ArrayList<String>( Arrays.asList( "foo", "bar" ) ) ) },
+            { Collections.synchronizedSet( new HashSet<String>( Arrays.asList( "foo", "bar" ) ) ) },
+            { Collections.synchronizedMap( m ) },
+        };
     }
     
     @SuppressWarnings( "unchecked" )


### PR DESCRIPTION
Previously copying an object with an unmodifiable or synchronized collection failed as the serializer's default behavior is to throw an exception. Updated to now perform the copy operation.

Note that my local editor auto removed trailing whitespace. If formatting options matter, I can revert that part of the change.

Added a single test case for each serializer. If one per collection type is desired, I would prefer to use a `DataProvider` due to the repetitive code (but that idiom isn't currently being used).
