### PR TITLE
Change EnumMapSerializer.copy to deep copy the value

### DIFF
--- a/src/main/java/de/javakaffee/kryoserializers/EnumMapSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/EnumMapSerializer.java
@@ -51,10 +51,16 @@ public class EnumMapSerializer extends Serializer<EnumMap<? extends Enum<?>, ?>>
     private static final Object FAKE_REFERENCE = new Object();
 
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public EnumMap<? extends Enum<?>, ?> copy (final Kryo kryo, final EnumMap<? extends Enum<?>, ?> original) {
-        return new EnumMap(original);
-    }
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public EnumMap<? extends Enum<?>, ?> copy(final Kryo kryo, final EnumMap<? extends Enum<?>, ?> original) {
+        // Make a shallow copy to copy the private key type of the original map without using reflection.
+        // This will work for empty original maps as well.
+        final EnumMap copy = new EnumMap(original);
+        for (final Map.Entry entry : original.entrySet()) {
+            copy.put((Enum)entry.getKey(), kryo.copy(entry.getValue()));
+        }
+        return copy;
+    }	
 
     @SuppressWarnings( { "unchecked", "rawtypes" } )
     private EnumMap<? extends Enum<?>, ?> create(final Kryo kryo, final Input input,

--- a/src/test/java/de/javakaffee/kryoserializers/EnumMapSerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/EnumMapSerializerTest.java
@@ -1,0 +1,67 @@
+package de.javakaffee.kryoserializers;
+
+import static org.testng.Assert.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.factories.SerializerFactory;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+/**
+ * A test case for the {@link EnumMapSerializer}.
+ */
+public class EnumMapSerializerTest {
+	private static enum Vipers {
+		SNAKE_CHARMER, BLACK_MAMBA, COTTONMOUTH, COPPERHEAD, CALIFORNIA_MOUNTAIN_SNAKE, SIDEWINDER;
+	}
+
+	private static enum Colors {
+		BLUE, ORANGE, PINK, WHITE, BROWN, BLONDE;
+	}
+
+    private Kryo _kryo;
+    private EnumMap<Vipers, Set<String>> _original;
+    
+    @BeforeTest
+    protected void beforeTest() {
+        _kryo = new Kryo();
+		_kryo.register(EnumMap.class, new EnumMapSerializer());
+		_original = new EnumMap<Vipers, Set<String>>(Vipers.class);
+    }
+    
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test(expectedExceptions={ClassCastException.class})
+    public void testCopyEmpty() throws Exception {
+        EnumMap copy = _kryo.copy(_original);        
+        // The next statement asserts that the key type of the copy is initialized correctly - 
+        // it should throw the expected ClassCastException.
+    	copy.put(Colors.BROWN, new HashSet<String>());
+    }
+
+	@Test
+    public void testDeepCopy() throws Exception {
+		final Set<String> mambaAka = new HashSet<String>();
+		mambaAka.add("Beatrix Kiddo");
+		mambaAka.add("The Bride");
+        _original.put(Vipers.BLACK_MAMBA, mambaAka);
+        
+		EnumMap<Vipers, Set<String>> copy = _kryo.copy(_original);        
+        assertNotSame(_original, copy);
+        assertTrue(copy.containsKey(Vipers.BLACK_MAMBA));
+        assertNotSame(_original.get(Vipers.BLACK_MAMBA), copy.get(Vipers.BLACK_MAMBA));
+        assertEquals(_original, copy);
+    }
+}


### PR DESCRIPTION
The previous implementation was problematic as it was not consistent with the spec - i.e. it shallow copied the EnumMap, instead of deep-copying it.

The new implementation uses a shallow copy as starting point, which initializes the key class of the EnumMap correctly (even when the EnumMap is empty).
After executing the shallow copy, a deep copy of the values is made.