### PR TITLE
Add Dexx Collection serializers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,7 +41,9 @@ A project that provides [kryo](https://github.com/EsotericSoftware/kryo) (v2 and
 * jodatime/JodaLocalDateTimeSerializer - serializer for joda's LocalDateTime
 * protobuf/ProtobufSerializer - serializer for protobuf GeneratedMessages
 * wicket/MiniMapSerializer - serializer for wicket's MiniMap
-
+* dexx/ListSerializer - serializer for dexx-collections' List
+* dexx/SetSerializer - serializer for dexx collecttions' Set
+* dexx/MapSerializer - serializer for dexx collections' Map
 
 # Usage
 To be able to use the serializers you have to add the jar to your classpath. If your build tool support maven repositories you can use this dependency:

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<!-- To be able to deploy snapshots/releases to sonatype / maven central: https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide -->
 	<parent>
 		<groupId>org.sonatype.oss</groupId>
@@ -213,6 +213,12 @@
 			<artifactId>guava</artifactId>
 			<version>17.0</version>
 			<optional>true</optional>
+		</dependency>
+		<dependency>
+            <groupId>com.github.andrewoma.dexx</groupId>
+			<artifactId>collection</artifactId>
+            <version>0.6</version>
+            <optional>true</optional>
 		</dependency>
 
 		<!-- Testing -->

--- a/src/main/java/de/javakaffee/kryoserializers/dexx/ListSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/dexx/ListSerializer.java
@@ -1,0 +1,70 @@
+package de.javakaffee.kryoserializers.dexx;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import com.github.andrewoma.dexx.collection.IndexedLists;
+import com.github.andrewoma.dexx.collection.List;
+
+/**
+ * A kryo {@link Serializer} for dexx {@link List}
+ */
+public class ListSerializer extends Serializer<List> {
+
+    private static final boolean DOES_NOT_ACCEPT_NULL = true;
+    private static final boolean IMMUTABLE = true;
+
+    public ListSerializer() {
+        super(DOES_NOT_ACCEPT_NULL, IMMUTABLE);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, List object) {
+        output.writeInt(object.size(), true);
+        for (Object elm : object) {
+            kryo.writeClassAndObject(output, elm);
+        }
+    }
+
+    @Override
+    public List<Object> read(Kryo kryo, Input input, Class<List> aClass) {
+        final int size = input.readInt(true);
+        final Object[] list = new Object[size];
+        for (int i = 0; i < size; ++i) {
+            list[i] = kryo.readClassAndObject(input);
+        }
+        return IndexedLists.copyOf(list);
+    }
+
+    /**
+     * Creates a new {@link  ImmutableListSerializer} and registers its serializer
+     *
+     * @param kryo the {@link Kryo} instance to set the serializer on
+     */
+    public static void registerSerializers(final Kryo kryo) {
+
+        final ListSerializer serializer = new ListSerializer();
+
+        kryo.register(List.class, serializer);
+
+        // Note:
+        //  Only registering above is good enough for serializing/deserializing.
+        //  but if using Kryo#copy, following is required.
+
+        kryo.register(IndexedLists.of().getClass(), serializer);
+        kryo.register(IndexedLists.of(1).getClass(), serializer);
+        kryo.register(IndexedLists.of(1,2).getClass(), serializer);
+        kryo.register(IndexedLists.of(1,2,3).getClass(), serializer);
+        kryo.register(IndexedLists.of(1,2,3,4).getClass(), serializer);
+        kryo.register(IndexedLists.of(1,2,3,4,5).getClass(), serializer);
+        kryo.register(IndexedLists.of(1,2,3,4,5,6).getClass(), serializer);
+        kryo.register(IndexedLists.of(1,2,3,4,5,6,7).getClass(), serializer);
+        kryo.register(IndexedLists.of(1,2,3,4,5,6,7,8).getClass(), serializer);
+        kryo.register(IndexedLists.of(1,2,3,4,5,6,7,8,9).getClass(), serializer);
+        kryo.register(IndexedLists.of(1,2,3,4,5,6,7,8,10).getClass(), serializer);
+        kryo.register(IndexedLists.of(1,2,3,4,5,6,7,8,10,11).getClass(), serializer);
+
+    }
+}

--- a/src/main/java/de/javakaffee/kryoserializers/dexx/MapSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/dexx/MapSerializer.java
@@ -1,0 +1,73 @@
+package de.javakaffee.kryoserializers.dexx;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import com.github.andrewoma.dexx.collection.Map;
+import com.github.andrewoma.dexx.collection.Maps;
+import com.github.andrewoma.dexx.collection.Pair;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Map.Entry;
+import java.util.Iterator;
+
+/**
+* A kryo {@link Serializer} for dexx {@link Map}
+ */
+public class MapSerializer extends Serializer<Map<Object, ? extends Object>> {
+
+    private static final boolean DOES_NOT_ACCEPT_NULL = true;
+    private static final boolean IMMUTABLE = true;
+
+    public MapSerializer() {
+        super(DOES_NOT_ACCEPT_NULL, IMMUTABLE);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, Map<Object, ? extends Object> immutableMap) {
+        kryo.writeObject(output, immutableMap.asMap());
+    }
+
+    @Override
+    public Map<Object, Object> read(Kryo kryo, Input input, Class<Map<Object, ? extends Object>> type) {
+        HashMap<Object, Object> map = kryo.readObject(input, HashMap.class);
+        ArrayList<Pair<Object, Object>> listOfPairs = new ArrayList();
+
+        for (Entry<Object, Object> entry : map.entrySet()) {
+            Pair pair = new Pair(entry.getKey(), entry.getValue());
+            listOfPairs.add(pair);
+        }
+
+        return Maps.copyOf(listOfPairs);
+    }
+
+    /**
+     * Creates a new {@link ImmutableMapSerializer} and registers its serializer
+     * for the several ImmutableMap related classes.
+     *
+     * @param kryo the {@link Kryo} instance to set the serializer on
+     */
+     public static void registerSerializers(final Kryo kryo) {
+
+         final MapSerializer serializer = new MapSerializer();
+
+         kryo.register(Map.class, serializer);
+         kryo.register(Maps.of().getClass(), serializer);
+
+         Object o1 = new Object();
+         Object o2 = new Object();
+         Object o3 = new Object();
+         Object o4 = new Object();
+         Object o5 = new Object();
+
+         kryo.register(Maps.of(o1, o1).getClass(), serializer);
+         kryo.register(Maps.of(o1, o1, o2, o2).getClass(), serializer);
+         kryo.register(Maps.of(o1, o1, o2, o2, o3, o3).getClass(), serializer);
+         kryo.register(Maps.of(o1, o1, o2, o2, o3, o3, o4, o4).getClass(), serializer);
+         kryo.register(Maps.of(o1, o1, o2, o2, o3, o3, o4, o4, o5, o5).getClass(), serializer);
+
+     }
+}

--- a/src/main/java/de/javakaffee/kryoserializers/dexx/SetSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/dexx/SetSerializer.java
@@ -1,0 +1,71 @@
+package de.javakaffee.kryoserializers.dexx;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import com.github.andrewoma.dexx.collection.Builder;
+import com.github.andrewoma.dexx.collection.Set;
+import com.github.andrewoma.dexx.collection.Sets;
+
+/**
+* A kryo {@link Serializer} for dexx {@link Set}
+ */
+public class SetSerializer extends Serializer<Set<Object>> {
+
+    private static final boolean DOES_NOT_ACCEPT_NULL = false;
+    private static final boolean IMMUTABLE = true;
+
+    public SetSerializer() {
+        super(DOES_NOT_ACCEPT_NULL, IMMUTABLE);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, Set<Object> object) {
+        output.writeInt(object.size(), true);
+        for (Object elm : object) {
+            kryo.writeClassAndObject(output, elm);
+        }
+    }
+
+    @Override
+    public Set<Object> read(Kryo kryo, Input input, Class<Set<Object>> type) {
+        final int size = input.readInt(true);
+        Builder<Object, Set<Object>> builder = Sets.builder();
+        for (int i = 0; i < size; ++i) {
+            builder.add(kryo.readClassAndObject(input));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Creates a new {@link ImmutableSetSerializer} and registers its serializer
+     * for the several ImmutableSet related classes.
+     *
+     * @param kryo the {@link Kryo} instance to set the serializer on
+     */
+    public static void registerSerializers(final Kryo kryo) {
+
+        final SetSerializer serializer = new SetSerializer();
+
+        kryo.register(Set.class, serializer);
+
+        // Note:
+        //  Only registering above is good enough for serializing/deserializing.
+        //  but if using Kryo#copy, following is required.
+
+        kryo.register(Sets.of().getClass(), serializer);
+        kryo.register(Sets.of(1).getClass(), serializer);
+        kryo.register(Sets.of(1,2,3).getClass(), serializer);
+        kryo.register(Sets.of(1,2,3,4).getClass(), serializer);
+        kryo.register(Sets.of(1,2,3,4,5).getClass(), serializer);
+        kryo.register(Sets.of(1,2,3,4,5,6).getClass(), serializer);
+        kryo.register(Sets.of(1,2,3,4,5,6,7).getClass(), serializer);
+        kryo.register(Sets.of(1,2,3,4,5,6,7,8).getClass(), serializer);
+        kryo.register(Sets.of(1,2,3,4,5,6,7,8,9).getClass(), serializer);
+        kryo.register(Sets.of(1,2,3,4,5,6,7,8,9,10).getClass(), serializer);
+        kryo.register(Sets.of(1,2,3,4,5,6,7,8,9,10,11).getClass(), serializer);
+
+    }
+}

--- a/src/test/java/de/javakaffee/kryoserializers/dexx/ListSerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/dexx/ListSerializerTest.java
@@ -1,0 +1,84 @@
+package de.javakaffee.kryoserializers.dexx;
+
+import static de.javakaffee.kryoserializers.KryoTest.deserialize;
+import static de.javakaffee.kryoserializers.KryoTest.serialize;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import com.esotericsoftware.kryo.Kryo;
+
+import com.github.andrewoma.dexx.collection.ArrayList;
+import com.github.andrewoma.dexx.collection.IndexedLists;
+import com.github.andrewoma.dexx.collection.List;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+/**
+ * Test for {@link ListSerializer}
+ */
+public class ListSerializerTest {
+
+    private Kryo _kryo;
+
+    @BeforeTest
+    public void setUp() throws Exception {
+        _kryo = new Kryo();
+
+        ListSerializer.registerSerializers(_kryo);
+    }
+
+    @Test(enabled = true)
+    public void testEmpty() {
+        final List<?> obj = IndexedLists.of();
+        final byte[] serialized = serialize(_kryo, obj);
+        final List<?> deserialized = deserialize(_kryo, serialized, List.class);
+        assertTrue(deserialized.isEmpty());
+        assertEquals(deserialized.size(), obj.size());
+    }
+
+    @Test(enabled = true)
+    public void testRegular() {
+        final List<?> obj = IndexedLists.of(3,4,5,6,7);
+        final byte[] serialized = serialize(_kryo, obj);
+        final List<?> deserialized = deserialize(_kryo, serialized, List.class);
+        assertEquals(deserialized, obj);
+    }
+
+    @Test(enabled = true)
+    public void testCopyOfIterable() {
+        final ArrayList<Object> iterable = new ArrayList<Object>();
+        iterable.append(new Object());
+        final List<?> obj = IndexedLists.copyOf(iterable.asList());
+        final byte[] serialized = serialize(_kryo, obj);
+        final List<?> deserialized = deserialize(_kryo, serialized, List.class);
+        assertEquals(deserialized, obj);
+    }
+
+    // Kryo#copy tests
+
+    @Test(enabled = true)
+    public void testCopyEmpty() {
+        final List<?> obj = IndexedLists.of();
+        final List<?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+    @Test(enabled = true)
+    public void testCopyRegular() {
+        final List<?> obj = IndexedLists.of(2,3,4,5);
+        final List<?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+    @Test(enabled = true)
+    public void testCopyCopyOfIterable() {
+        final ArrayList<Object> iterable = new ArrayList<Object>();
+        iterable.append(new Object());
+        final List<?> obj = IndexedLists.copyOf(iterable.asList());
+        List<?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+}

--- a/src/test/java/de/javakaffee/kryoserializers/dexx/MapSerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/dexx/MapSerializerTest.java
@@ -1,0 +1,61 @@
+package de.javakaffee.kryoserializers.dexx;
+
+import com.esotericsoftware.kryo.Kryo;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.github.andrewoma.dexx.collection.Map;
+import com.github.andrewoma.dexx.collection.Maps;
+
+import static de.javakaffee.kryoserializers.KryoTest.deserialize;
+import static de.javakaffee.kryoserializers.KryoTest.serialize;
+import static org.testng.Assert.*;
+
+/**
+* Test for {@link MapSerializer}
+ */
+public class MapSerializerTest {
+
+    private Kryo _kryo;
+
+    @BeforeTest
+    public void setUp() throws Exception {
+        _kryo = new Kryo();
+
+        MapSerializer.registerSerializers(_kryo);
+    }
+
+    @Test(enabled = true)
+    public void testEmpty() {
+        final Map<?, ?> obj = Maps.of();
+        final byte[] serialized = serialize(_kryo, obj);
+        final Map<?, ?> deserialized = deserialize(_kryo, serialized, Map.class);
+        assertTrue(deserialized.isEmpty());
+        assertEquals(deserialized.size(), obj.size());
+    }
+
+    @Test(enabled = true)
+    public void testRegular() {
+        final Map<?, ?> obj = Maps.of(3, "k", 5, "r", 6, "y");
+        final byte[] serialized = serialize(_kryo, obj);
+        final Map<?, ?> deserialized = deserialize(_kryo, serialized, Map.class);
+        assertEquals(deserialized, obj);
+    }
+
+    // Kryo#copy tests
+
+    @Test(enabled = true)
+    public void testCopyEmpty() {
+        final Map<?, ?> obj = Maps.of();
+        final Map<?, ?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+    @Test(enabled = true)
+    public void testCopyRegular() {
+        final Map<?, ?> obj = Maps.of(1, 2, 3, 4);
+        final Map<?, ?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+}

--- a/src/test/java/de/javakaffee/kryoserializers/dexx/SetSerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/dexx/SetSerializerTest.java
@@ -1,0 +1,61 @@
+package de.javakaffee.kryoserializers.dexx;
+
+import com.esotericsoftware.kryo.Kryo;
+import static org.testng.Assert.*;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static de.javakaffee.kryoserializers.KryoTest.deserialize;
+import static de.javakaffee.kryoserializers.KryoTest.serialize;
+
+import com.github.andrewoma.dexx.collection.Set;
+import com.github.andrewoma.dexx.collection.Sets;
+
+/**
+ * Test for {@link SetSerializer}.
+ */
+public class SetSerializerTest {
+
+    private Kryo _kryo;
+
+    @BeforeTest
+    public void setUp() throws Exception {
+        _kryo = new Kryo();
+
+        SetSerializer.registerSerializers(_kryo);
+    }
+
+    @Test(enabled = true)
+    public void testEmpty() {
+        final Set<?> obj = Sets.of();
+        final byte[] serialized = serialize( _kryo, obj );
+        final Set<?> deserialized = deserialize(_kryo, serialized, Set.class);
+        assertTrue(deserialized.isEmpty());
+        assertEquals(deserialized.size(), obj.size());
+    }
+
+    @Test(enabled = true)
+    public void testRegular() {
+        final Set<?> obj = Sets.of(3, 4, 5, 6);
+        final byte[] serialized = serialize( _kryo, obj );
+        final Set<?> deserialized = deserialize(_kryo, serialized, Set.class);
+        assertEquals(deserialized, obj);
+    }
+
+    // Kryo#copy tests
+
+    @Test(enabled = true)
+    public void testCopyEmpty() {
+        final Set<?> obj = Sets.of();
+        final Set<?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+    @Test(enabled = true)
+    public void testCopyRegular() {
+        final Set<?> obj = Sets.of(1, 2, 3);
+        final Set<?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+}


### PR DESCRIPTION
Dexx provides Dexx Collections a port of Scala's immutable, persistent collection classes in java.

Test cover the base cases, I can add more if needed.