### PR TITLE
Upgrade TestNG.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,18 +216,24 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-            <groupId>com.github.andrewoma.dexx</groupId>
+			<groupId>com.github.andrewoma.dexx</groupId>
 			<artifactId>collection</artifactId>
-            <version>0.6</version>
-            <optional>true</optional>
+			<version>0.6</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Testing -->
 		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
-			<version>5.10</version>
-			<classifier>jdk15</classifier>
+			<version>6.8.21</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Required for CGLibProxySerializerTest -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
 
@@ -255,6 +261,13 @@
 	</dependencies>
 
 	<repositories>
+		<!-- Required for TestNG -->
+		<repository>
+			<id>jcenter</id>
+			<name>bintray</name>
+			<url>http://jcenter.bintray.com</url>
+		</repository>
+
 		<!--
 		  kryo jars were uploaded as 3rd party jars following
 		  https://docs.sonatype.org/display/Repository/Uploading+3rd-party+Artifacts+to+Maven+Central

--- a/src/test/java/de/javakaffee/kryoserializers/cglib/CGLibProxySerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/cglib/CGLibProxySerializerTest.java
@@ -18,7 +18,7 @@ package de.javakaffee.kryoserializers.cglib;
 
 import static de.javakaffee.kryoserializers.KryoTest.deserialize;
 import static de.javakaffee.kryoserializers.KryoTest.serialize;
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -38,7 +38,7 @@ import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.InvocationHandler;
 
 import org.objenesis.strategy.StdInstantiatorStrategy;
-import org.testng.Assert;
+
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -105,8 +105,8 @@ public class CGLibProxySerializerTest {
         Log.TRACE = true;
         final ClassToProxy obj = new ClassToProxy();
         obj._value = "foo";
-		final ClassToProxy proxy1 = createProxy( obj );
-		final ClassToProxy proxy2 = createProxy( obj );
+        final ClassToProxy proxy1 = createProxy( obj );
+        final ClassToProxy proxy2 = createProxy( obj );
         final List<ClassToProxy> proxies = Arrays.asList( proxy1, proxy2 );
         final OutputStream out = new FileOutputStream( new File( "/tmp/cglib-data-1.ser" ) );
         final Output output = new Output(out);
@@ -130,13 +130,13 @@ public class CGLibProxySerializerTest {
         System.out.println(proxies);
         assertEquals(2, proxies.size());
         final ClassToProxy proxy1 = proxies.get(0);
-		assertEquals( "foo", proxy1.getValue() );
+        assertEquals( "foo", proxy1.getValue() );
         final ClassToProxy proxy2 = proxies.get(1);
-		assertEquals( "foo", proxy2.getValue() );
+        assertEquals( "foo", proxy2.getValue() );
         // test that the proxied object is referenced by both proxies
-		proxy1.setValue("bar");
-		assertEquals( "bar", proxy1.getValue() );
-		assertEquals( "bar", proxy2.getValue() );
+        proxy1.setValue("bar");
+        assertEquals( "bar", proxy1.getValue() );
+        assertEquals( "bar", proxy2.getValue() );
     }
 
     @Test( enabled = true )
@@ -171,7 +171,7 @@ public class CGLibProxySerializerTest {
         
         final byte[] serialized = serialize(_kryo, proxy);
         final ClassToProxy deserialized = deserialize(_kryo, serialized, proxy.getClass() );
-        Assert.assertEquals( deserialized.getValue(), proxy.getValue() );
+        assertEquals( deserialized.getValue(), proxy.getValue() );
     }
 
     /**
@@ -181,12 +181,12 @@ public class CGLibProxySerializerTest {
     public void testCGLibProxyForExistingFormat() {
         final Map<String, String> proxy = createProxy( new HashMap<String, String>() );
         proxy.put( "foo", "bar" );
-        Assert.assertEquals( proxy.get( "foo" ), "bar" );
+        assertEquals( proxy.get( "foo" ), "bar" );
         
         final byte[] serialized = serialize(_kryo, proxy);
         @SuppressWarnings( "unchecked" )
         final Map<String, String> deserialized = deserialize(_kryo, serialized, proxy.getClass() );
-        Assert.assertEquals( deserialized.get( "foo" ), proxy.get( "foo" ) );
+        assertEquals( deserialized.get( "foo" ), proxy.get( "foo" ) );
     }
 
     @SuppressWarnings( "unchecked" )


### PR DESCRIPTION
- TestNG is old, and will not allow running tests from within IntelliJ
  IDEA.

- Upgrade to 6.8.21, which is the highest version that still supports
  JDK 1.6.

- Fix asserts in CGLibProxySerializerTest that (mistakenly?) use JUnit;
  use TestNG instead, which is the library default.