### PR TITLE
Adding support for Protobuf v3.0.0+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>2.6.1</version>
+			<version>3.0.0</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/src/main/java/de/javakaffee/kryoserializers/protobuf/ProtobufSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/protobuf/ProtobufSerializer.java
@@ -4,13 +4,13 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import com.google.protobuf.GeneratedMessage;
+import com.google.protobuf.GeneratedMessageV3;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import static com.esotericsoftware.kryo.Kryo.NULL;
 
-public class ProtobufSerializer<T extends GeneratedMessage> extends Serializer<T> {
+public class ProtobufSerializer<T extends GeneratedMessageV3> extends Serializer<T> {
 
     private Method parseFromMethod = null;
 

--- a/src/test/java/de/javakaffee/kryoserializers/protobuf/SampleProtoAOuterClass.java
+++ b/src/test/java/de/javakaffee/kryoserializers/protobuf/SampleProtoAOuterClass.java
@@ -39,11 +39,11 @@ public final class SampleProtoAOuterClass {
    * Protobuf type {@code ProtocolBuffers.SampleProtoA}
    */
   public static final class SampleProtoA extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:ProtocolBuffers.SampleProtoA)
       SampleProtoAOrBuilder {
     // Use SampleProtoA.newBuilder() to construct.
-    private SampleProtoA(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private SampleProtoA(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
       this.unknownFields = builder.getUnknownFields();
     }
@@ -115,7 +115,7 @@ public final class SampleProtoAOuterClass {
       return de.javakaffee.kryoserializers.protobuf.SampleProtoAOuterClass.internal_static_ProtocolBuffers_SampleProtoA_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return de.javakaffee.kryoserializers.protobuf.SampleProtoAOuterClass.internal_static_ProtocolBuffers_SampleProtoA_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -309,7 +309,7 @@ public final class SampleProtoAOuterClass {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -317,7 +317,7 @@ public final class SampleProtoAOuterClass {
      * Protobuf type {@code ProtocolBuffers.SampleProtoA}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:ProtocolBuffers.SampleProtoA)
         de.javakaffee.kryoserializers.protobuf.SampleProtoAOuterClass.SampleProtoAOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -325,7 +325,7 @@ public final class SampleProtoAOuterClass {
         return de.javakaffee.kryoserializers.protobuf.SampleProtoAOuterClass.internal_static_ProtocolBuffers_SampleProtoA_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return de.javakaffee.kryoserializers.protobuf.SampleProtoAOuterClass.internal_static_ProtocolBuffers_SampleProtoA_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -338,12 +338,12 @@ public final class SampleProtoAOuterClass {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {
         }
       }
       private static Builder create() {
@@ -565,7 +565,7 @@ public final class SampleProtoAOuterClass {
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_ProtocolBuffers_SampleProtoA_descriptor;
   private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_ProtocolBuffers_SampleProtoA_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -596,7 +596,7 @@ public final class SampleProtoAOuterClass {
     internal_static_ProtocolBuffers_SampleProtoA_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_ProtocolBuffers_SampleProtoA_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_ProtocolBuffers_SampleProtoA_descriptor,
         new java.lang.String[] { "Name", "MessageId", });
   }

--- a/src/test/java/de/javakaffee/kryoserializers/protobuf/SampleProtoBOuterClass.java
+++ b/src/test/java/de/javakaffee/kryoserializers/protobuf/SampleProtoBOuterClass.java
@@ -53,11 +53,11 @@ public final class SampleProtoBOuterClass {
    * Protobuf type {@code ProtocolBuffers.SampleProtoB}
    */
   public static final class SampleProtoB extends
-      com.google.protobuf.GeneratedMessage implements
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:ProtocolBuffers.SampleProtoB)
       SampleProtoBOrBuilder {
     // Use SampleProtoB.newBuilder() to construct.
-    private SampleProtoB(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private SampleProtoB(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
       this.unknownFields = builder.getUnknownFields();
     }
@@ -135,7 +135,7 @@ public final class SampleProtoBOuterClass {
       return de.javakaffee.kryoserializers.protobuf.SampleProtoBOuterClass.internal_static_ProtocolBuffers_SampleProtoB_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return de.javakaffee.kryoserializers.protobuf.SampleProtoBOuterClass.internal_static_ProtocolBuffers_SampleProtoB_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -391,7 +391,7 @@ public final class SampleProtoBOuterClass {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -399,7 +399,7 @@ public final class SampleProtoBOuterClass {
      * Protobuf type {@code ProtocolBuffers.SampleProtoB}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:ProtocolBuffers.SampleProtoB)
         de.javakaffee.kryoserializers.protobuf.SampleProtoBOuterClass.SampleProtoBOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -407,7 +407,7 @@ public final class SampleProtoBOuterClass {
         return de.javakaffee.kryoserializers.protobuf.SampleProtoBOuterClass.internal_static_ProtocolBuffers_SampleProtoB_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return de.javakaffee.kryoserializers.protobuf.SampleProtoBOuterClass.internal_static_ProtocolBuffers_SampleProtoB_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -420,12 +420,12 @@ public final class SampleProtoBOuterClass {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {
         }
       }
       private static Builder create() {
@@ -746,7 +746,7 @@ public final class SampleProtoBOuterClass {
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_ProtocolBuffers_SampleProtoB_descriptor;
   private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_ProtocolBuffers_SampleProtoB_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -778,7 +778,7 @@ public final class SampleProtoBOuterClass {
     internal_static_ProtocolBuffers_SampleProtoB_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_ProtocolBuffers_SampleProtoB_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_ProtocolBuffers_SampleProtoB_descriptor,
         new java.lang.String[] { "Identifier", "State", "City", });
   }


### PR DESCRIPTION
For projects that rely on Protobuf v3.0.0 (GA) and upwards the current Kryo-serializers can not be used. This commit enables it but it does break compatibility for projects relying on earlier versions of Protobuf.
