### PR TITLE
Make ArraysAsListSerializer not immutable

### DIFF
--- a/src/main/java/de/javakaffee/kryoserializers/ArraysAsListSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/ArraysAsListSerializer.java
@@ -46,8 +46,6 @@ public class ArraysAsListSerializer extends Serializer<List<?>> {
         } catch ( final Exception e ) {
             throw new RuntimeException( e );
         }
-        // Immutable causes #copy(obj) to return the original object
-        setImmutable(true);
     }
 
     @Override


### PR DESCRIPTION
Being immutable is incorrect because elements of it may be mutable.

Closes #46 