### PR TITLE
Update pom.xml to provide support to kryo 4.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 				<configuration>
 					<instructions>
 						<Import-Package><![CDATA[
-						com.esotericsoftware.kryo*;version="[3.0.3,4.0)",
+						com.esotericsoftware.kryo*;version="[3.0.3,4.1)",
 						com.esotericsoftware.minlog*;version="[1.2,2.0)",
 						sun.reflect;resolution:=optional,
 						*


### PR DESCRIPTION
Although com.esotericsoftware.kryo dependency is provided inside dependencies block with version 4.0.0, you are not including it in generated MANIFEST.MF file due to com.esotericsoftware.kryo*;version="[3.0.3,4.0)"