### PR TITLE
Revert "Make ArraysAsListSerializer not immutable"

### DIFF
--- a/src/main/java/de/javakaffee/kryoserializers/ArraysAsListSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/ArraysAsListSerializer.java
@@ -46,6 +46,8 @@ public class ArraysAsListSerializer extends Serializer<List<?>> {
         } catch ( final Exception e ) {
             throw new RuntimeException( e );
         }
+        // Immutable causes #copy(obj) to return the original object
+        setImmutable(true);
     }
 
     @Override


### PR DESCRIPTION
Reverts magro/kryo-serializers#79

The build failed with
```
[ERROR] testCopyJavaUtilArraysAsList(de.javakaffee.kryoserializers.KryoTest)  Time elapsed: 0.008 s  <<< FAILURE!
com.esotericsoftware.kryo.KryoException: Serializer does not support copy: de.javakaffee.kryoserializers.ArraysAsListSerializer
	at de.javakaffee.kryoserializers.KryoTest.testCopyJavaUtilArraysAsList(KryoTest.java:578)
```