### PR TITLE
Guava Table support and smaller fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,15 +36,19 @@ A project that provides [kryo](https://github.com/EsotericSoftware/kryo) (v2, v3
 * dexx/SetSerializer - serializer for dexx collecttions' Set
 * dexx/MapSerializer - serializer for dexx collections' Map
 * guava/ArrayListMultimapSerializer - serializer for guava-libraries' ArrayListMultimap
+* guava/ArrayTableSerializer - serializer for guava-libraries' ArrayTable
+* guava/HashBasedTableSerializer - serializer for guava-libraries' HashBasedTable
 * guava/HashMultimapSerializer -- serializer for guava-libraries' HashMultimap
 * guava/ImmutableListSerializer - serializer for guava-libraries' ImmutableList
 * guava/ImmutableSetSerializer - serializer for guava-libraries' ImmutableSet
 * guava/ImmutableMapSerializer - serializer for guava-libraries' ImmutableMap
 * guava/ImmutableMultimapSerializer - serializer for guava-libraries' ImmutableMultimap
 * guava/ImmutableSortedSetSerializer - serializer for guava-libraries' ImmutableSortedSet
+* guava/ImmutableTableSerializer - serializer for guava-libraries' ImmutableTable
 * guava/LinkedHashMultimapSerializer - serializer for guava-libraries' LinkedHashMultimap
 * guava/LinkedListMultimapSerializer - serializer for guava-libraries' LinkedListMultimap
 * guava/ReverseListSerializer - serializer for guava-libraries' Lists.ReverseList / Lists.reverse
+* guava/TreeBasedTableSerializer - serializer for guava-libraries' TreeBasedTable
 * guava/TreeMultimapSerializer - serializer for guava-libraries' TreeMultimap
 * guava/UnmodifiableNavigableSetSerializer - serializer for guava-libraries' UnmodifiableNavigableSet
 * jodatime/JodaDateTimeSerializer - serializer for joda's DateTime
@@ -101,19 +105,23 @@ kryo.register( LocalDateTime.class, new JodaLocalTimeSerializer() );
 kryo.register( SampleProtoA.class, new ProtobufSerializer() ); // or override Kryo.getDefaultSerializer as shown below
 // wicket
 kryo.register( MiniMap.class, new MiniMapSerializer() );
-// guava ImmutableList, ImmutableSet, ImmutableMap, ImmutableMultimap, ReverseList, UnmodifiableNavigableSet
+// guava ImmutableList, ImmutableSet, ImmutableMap, ImmutableMultimap, ImmutableTable, ReverseList, UnmodifiableNavigableSet
 ImmutableListSerializer.registerSerializers( kryo );
 ImmutableSetSerializer.registerSerializers( kryo );
 ImmutableMapSerializer.registerSerializers( kryo );
 ImmutableMultimapSerializer.registerSerializers( kryo );
+ImmutableTableSerializer.registerSerializers( kryo );
 ReverseListSerializer.registerSerializers( kryo );
 UnmodifiableNavigableSetSerializer.registerSerializers( kryo );
-// guava ArrayListMultimap, HashMultimap, LinkedHashMultimap, LinkedListMultimap, TreeMultimap
+// guava ArrayListMultimap, HashMultimap, LinkedHashMultimap, LinkedListMultimap, TreeMultimap, ArrayTable, HashBasedTable, TreeBasedTable
 ArrayListMultimapSerializer.registerSerializers( kryo );
 HashMultimapSerializer.registerSerializers( kryo );
 LinkedHashMultimapSerializer.registerSerializers( kryo );
 LinkedListMultimapSerializer.registerSerializers( kryo );
 TreeMultimapSerializer.registerSerializers( kryo );
+ArrayTableSerializer.registerSerializers( kryo );
+HashBasedTableSerializer.registerSerializers( kryo );
+TreeBasedTableSerializer.registerSerializers( kryo );
 ```
 
 The following code snippet shows how to use the `KryoReflectionFactorySupport` (can only be used with sun/oracle jdk!) and how other serializers are registered via the `getDefaultSerializer` lookup. If you don't want to use the `KryoReflectionFactorySupport` you can override the `getDefaultSerializer` method for your `new Kryo()` instance.

--- a/src/main/java/de/javakaffee/kryoserializers/guava/ArrayTableSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/guava/ArrayTableSerializer.java
@@ -1,0 +1,84 @@
+package de.javakaffee.kryoserializers.guava;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Registration;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.common.collect.ArrayTable;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * A kryo {@link Serializer} for guava-libraries {@link ArrayTable}.
+ */
+public class ArrayTableSerializer<R, C, V> extends TableSerializerBase<R, C, V, ArrayTable<R, C, V>> {
+
+    private static final boolean HANDLES_NULL = false;
+    private static final boolean IMMUTABLE = false;
+
+    public ArrayTableSerializer() {
+        super(HANDLES_NULL, IMMUTABLE);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, ArrayTable<R, C, V> table) {
+        List<R> rowKeys = table.rowKeyList();
+        List<C> columnKeys = table.columnKeyList();
+        kryo.writeClassAndObject(output, rowKeys);
+        kryo.writeClassAndObject(output, columnKeys);
+        for (R rowKey : rowKeys) {
+            for (C columnKey : columnKeys) {
+                V val = table.get(rowKey, columnKey);
+                kryo.writeClassAndObject(output, val);
+            }
+        }
+    }
+
+    @Override
+    public ArrayTable<R, C, V> read(Kryo kryo, Input input, Class<? extends ArrayTable<R, C, V>> type) {
+        List<R> rowKeys = (List<R>) kryo.readClassAndObject(input);
+        List<C> columnKeys = (List<C>) kryo.readClassAndObject(input);
+        ArrayTable<R, C, V> table = ArrayTable.create(rowKeys, columnKeys);
+        for (R rowKey : rowKeys) {
+            for (C columnKey : columnKeys) {
+                V val = (V) kryo.readClassAndObject(input);
+                table.put(rowKey, columnKey, val);
+            }
+        }
+        return table;
+    }
+
+    @Override
+    public ArrayTable<R, C, V> copy(final Kryo kryo, final ArrayTable<R, C, V> original) {
+        return ArrayTable.create(original);
+    }
+
+    /* kryo.getSerializer (invoking kryo.getRegistration) throws an exception if registration is required,
+     * therefore we're getting a potentially existing serializer on another way.
+     */
+    private static Serializer<?> getSerializer(Kryo kryo, Class<?> type) {
+        Registration registration = kryo.getClassResolver().getRegistration(type);
+        return registration != null ? registration.getSerializer() : null;
+    }
+
+    /**
+     * Creates a new {@link ArrayTableSerializer} and registers its serializer.
+     *
+     * @param kryo the {@link Kryo} instance to set the serializer on
+     */
+    public static void registerSerializers(final Kryo kryo) {
+
+        // ImmutableList is used by ArrayTable. However,
+        // we already have a separate serializer class for ImmutableList,
+        // ImmutableListSerializer. If it is not already being used, register it.
+        Serializer immutableListSerializer = getSerializer(kryo, ImmutableList.class);
+        if (!(immutableListSerializer instanceof ImmutableListSerializer)) {
+            ImmutableListSerializer.registerSerializers(kryo);
+        }
+
+        final ArrayTableSerializer serializer = new ArrayTableSerializer();
+        kryo.register(ArrayTable.class, serializer);
+    }
+}

--- a/src/main/java/de/javakaffee/kryoserializers/guava/HashBasedTableSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/guava/HashBasedTableSerializer.java
@@ -1,0 +1,47 @@
+package de.javakaffee.kryoserializers.guava;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.common.collect.HashBasedTable;
+
+/**
+ * A kryo {@link Serializer} for guava-libraries {@link HashBasedTable}.
+ */
+public class HashBasedTableSerializer<R, C, V> extends TableSerializerBase<R, C, V, HashBasedTable<R, C, V>> {
+
+    private static final boolean HANDLES_NULL = false;
+    private static final boolean IMMUTABLE = false;
+
+    public HashBasedTableSerializer() {
+        super(HANDLES_NULL, IMMUTABLE);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, HashBasedTable<R, C, V> table) {
+        super.writeTable(kryo, output, table);
+    }
+
+    @Override
+    public HashBasedTable<R, C, V> read(Kryo kryo, Input input, Class<? extends HashBasedTable<R, C, V>> type) {
+        HashBasedTable<R, C, V> table = HashBasedTable.create();
+        super.readTable(kryo, input, table);
+        return table;
+    }
+
+    @Override
+    public HashBasedTable<R, C, V> copy(final Kryo kryo, final HashBasedTable<R, C, V> original) {
+        return HashBasedTable.create(original);
+    }
+
+    /**
+     * Creates a new {@link HashBasedTableSerializer} and registers its serializer.
+     *
+     * @param kryo the {@link Kryo} instance to set the serializer on
+     */
+    public static void registerSerializers(final Kryo kryo) {
+        final HashBasedTableSerializer serializer = new HashBasedTableSerializer();
+        kryo.register(HashBasedTable.class, serializer);
+    }
+}

--- a/src/main/java/de/javakaffee/kryoserializers/guava/ImmutableMapSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/guava/ImmutableMapSerializer.java
@@ -5,6 +5,7 @@ import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Maps;
 
 import java.util.EnumMap;
@@ -48,6 +49,16 @@ public class ImmutableMapSerializer extends Serializer<ImmutableMap<Object, ? ex
 
         final ImmutableMapSerializer serializer = new ImmutableMapSerializer();
 
+        // ImmutableMap (abstract class)
+        //  +- EmptyImmutableBiMap
+        //  +- SingletonImmutableBiMap
+        //  +- RegularImmutableMap
+        //  +- ImmutableEnumMap
+        //  +- RowMap from DenseImmutableTable
+        //  +- Row from DenseImmutableTable
+        //  +- ColumnMap from DenseImmutableTable
+        //  +- Column from DenseImmutableTable
+
         kryo.register(ImmutableMap.class, serializer);
         kryo.register(ImmutableMap.of().getClass(), serializer);
 
@@ -57,12 +68,22 @@ public class ImmutableMapSerializer extends Serializer<ImmutableMap<Object, ? ex
         kryo.register(ImmutableMap.of(o1, o1).getClass(), serializer);
         kryo.register(ImmutableMap.of(o1, o1, o2, o2).getClass(), serializer);
 
-        Map<DummyEnum,Object> enumMap = new EnumMap<DummyEnum, Object>(DummyEnum.class);
+        Map<DummyEnum, Object> enumMap = new EnumMap<DummyEnum, Object>(DummyEnum.class);
         for (DummyEnum e : DummyEnum.values()) {
             enumMap.put(e, o1);
         }
 
         kryo.register(ImmutableMap.copyOf(enumMap).getClass(), serializer);
+
+        ImmutableTable<Object, Object, Object> denseImmutableTable = ImmutableTable.builder()
+                .put("a", 1, 1)
+                .put("b", 1, 1)
+                .build();
+
+        kryo.register(denseImmutableTable.rowMap().getClass(), serializer); // RowMap
+        kryo.register(denseImmutableTable.rowMap().get("a").getClass(), serializer); // Row
+        kryo.register(denseImmutableTable.columnMap().getClass(), serializer); // ColumnMap
+        kryo.register(denseImmutableTable.columnMap().get(1).getClass(), serializer); // Column
     }
 
     private enum DummyEnum {

--- a/src/main/java/de/javakaffee/kryoserializers/guava/ImmutableTableSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/guava/ImmutableTableSerializer.java
@@ -1,0 +1,65 @@
+package de.javakaffee.kryoserializers.guava;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.common.collect.ImmutableTable;
+
+/**
+ * A kryo {@link Serializer} for guava-libraries {@link ImmutableTable}.
+ */
+public class ImmutableTableSerializer<R, C, V> extends TableSerializerBase<R, C, V, ImmutableTable<R, C, V>> {
+
+    private static final boolean HANDLES_NULL = false;
+    private static final boolean IMMUTABLE = true;
+
+    public ImmutableTableSerializer() {
+        super(HANDLES_NULL, IMMUTABLE);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, ImmutableTable<R, C, V> immutableTable) {
+        super.writeTable(kryo, output, immutableTable);
+    }
+
+    @Override
+    public ImmutableTable<R, C, V> read(Kryo kryo, Input input, Class<? extends ImmutableTable<R, C, V>> type) {
+        final ImmutableTable.Builder<R, C, V> builder = ImmutableTable.builder();
+        super.readTable(kryo, input, new CellConsumer<R, C, V>() {
+            @Override
+            public void accept(R r, C c, V v) {
+                builder.put(r, c, v);
+            }
+        });
+        return builder.build();
+    }
+
+    /**
+     * Creates a new {@link ImmutableTableSerializer} and registers its serializer.
+     *
+     * @param kryo the {@link Kryo} instance to set the serializer on
+     */
+    public static void registerSerializers(final Kryo kryo) {
+
+        // ImmutableTable (abstract class)
+        //  +- SparseImmutableTable
+        //  |   SparseImmutableTable
+        //  +- DenseImmutableTable
+        //  |   Used when more than half of the cells have values
+        //  +- SingletonImmutableTable
+        //  |   Optimized for Table with only 1 element.
+
+        final ImmutableTableSerializer serializer = new ImmutableTableSerializer();
+
+        kryo.register(ImmutableTable.class, serializer); // ImmutableTable
+        kryo.register(ImmutableTable.of().getClass(), serializer); // SparseImmutableTable
+        kryo.register(ImmutableTable.of(1, 2, 3).getClass(), serializer);  // SingletonImmutableTable
+
+        kryo.register(ImmutableTable.builder()
+                .put("a", 1, 1)
+                .put("b", 1, 1)
+                .build().getClass(), serializer); // DenseImmutableTable
+
+    }
+}

--- a/src/main/java/de/javakaffee/kryoserializers/guava/TableSerializerBase.java
+++ b/src/main/java/de/javakaffee/kryoserializers/guava/TableSerializerBase.java
@@ -1,0 +1,50 @@
+package de.javakaffee.kryoserializers.guava;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.common.collect.Table;
+
+import java.util.Set;
+
+
+public abstract class TableSerializerBase<R, C, V, T extends Table<R, C, V>> extends Serializer<T> {
+
+    public TableSerializerBase(boolean doesNotAcceptNull, boolean immutable) {
+        super(doesNotAcceptNull, immutable);
+    }
+
+    public void writeTable(Kryo kryo, Output output, Table<R, C, V> table) {
+        Set<Table.Cell<R, C, V>> cells = table.cellSet();
+        output.writeInt(cells.size(), true);
+        for (Table.Cell<R, C, V> cell : cells) {
+            kryo.writeClassAndObject(output, cell.getRowKey());
+            kryo.writeClassAndObject(output, cell.getColumnKey());
+            kryo.writeClassAndObject(output, cell.getValue());
+        }
+    }
+
+    public void readTable(Kryo kryo, Input input, final Table<R, C, V> table) {
+        this.readTable(kryo, input, new CellConsumer<R, C, V>() {
+            @Override
+            public void accept(R r, C c, V v) {
+                table.put(r, c, v);
+            }
+        });
+    }
+
+    public void readTable(Kryo kryo, Input input, CellConsumer<R, C, V> cellConsumer) {
+        final int size = input.readInt(true);
+        for (int i = 0; i < size; ++i) {
+            R rowKey = (R) kryo.readClassAndObject(input);
+            C colKey = (C) kryo.readClassAndObject(input);
+            V value = (V) kryo.readClassAndObject(input);
+            cellConsumer.accept(rowKey, colKey, value);
+        }
+    }
+
+    interface CellConsumer<R, C, V> {
+        void accept(R rowKey, C columnKey, V value);
+    }
+}

--- a/src/main/java/de/javakaffee/kryoserializers/guava/TreeBasedTableSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/guava/TreeBasedTableSerializer.java
@@ -1,0 +1,57 @@
+package de.javakaffee.kryoserializers.guava;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
+import com.google.common.collect.TreeBasedTable;
+
+import java.util.Comparator;
+import java.util.Set;
+
+/**
+ * A kryo {@link Serializer} for guava-libraries {@link TreeBasedTable}.
+ */
+public class TreeBasedTableSerializer<R extends Comparable, C extends Comparable, V> extends TableSerializerBase<R, C, V, TreeBasedTable<R, C, V>> {
+
+    private static final boolean HANDLES_NULL = false;
+    private static final boolean IMMUTABLE = false;
+
+    public TreeBasedTableSerializer() {
+        super(HANDLES_NULL, IMMUTABLE);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, TreeBasedTable<R, C, V> table) {
+        kryo.writeClassAndObject(output, table.rowComparator());
+        kryo.writeClassAndObject(output, table.columnComparator());
+        super.writeTable(kryo, output, table);
+    }
+
+    @Override
+    public TreeBasedTable<R, C, V> read(Kryo kryo, Input input, Class<? extends TreeBasedTable<R, C, V>> type) {
+        Comparator<? super Comparable> rowComparator = (Comparator<? super Comparable>) kryo.readClassAndObject(input);
+        Comparator<? super Comparable> columnComparator = (Comparator<? super Comparable>) kryo.readClassAndObject(input);
+        TreeBasedTable<R, C, V> table = TreeBasedTable.create(rowComparator, columnComparator);
+        super.readTable(kryo, input, table);
+        return table;
+    }
+
+    @Override
+    public TreeBasedTable<R, C, V> copy(final Kryo kryo, final TreeBasedTable<R, C, V> original) {
+        return TreeBasedTable.create(original);
+    }
+
+    /**
+     * Creates a new {@link TreeBasedTableSerializer} and registers its serializer.
+     *
+     * @param kryo the {@link Kryo} instance to set the serializer on
+     */
+    public static void registerSerializers(final Kryo kryo) {
+        final TreeBasedTableSerializer serializer = new TreeBasedTableSerializer();
+        kryo.register(TreeBasedTable.class, serializer);
+    }
+}

--- a/src/main/java/de/javakaffee/kryoserializers/guava/TreeMultimapSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/guava/TreeMultimapSerializer.java
@@ -7,6 +7,8 @@ import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
 
+import java.util.Comparator;
+
 /**
  * A kryo {@link Serializer} for guava-libraries {@link TreeMultimap}.
  * For reading / writing, the default comparator is assumed so the multimaps are not null-safe.
@@ -25,12 +27,16 @@ public class TreeMultimapSerializer extends MultimapSerializerBase<Comparable, C
 
     @Override
     public void write(Kryo kryo, Output output, TreeMultimap<Comparable, Comparable> multimap) {
+        kryo.writeClassAndObject(output, multimap.keyComparator());
+        kryo.writeClassAndObject(output, multimap.valueComparator());
         writeMultimap(kryo, output, multimap);
     }
 
     @Override
     public TreeMultimap<Comparable, Comparable> read(Kryo kryo, Input input, Class<? extends TreeMultimap<Comparable, Comparable>> type) {
-        final TreeMultimap<Comparable, Comparable> multimap = TreeMultimap.create();
+        Comparator<? super Comparable> keyComparator = (Comparator<? super Comparable>) kryo.readClassAndObject(input);
+        Comparator<? super Comparable> valueComparator = (Comparator<? super Comparable>) kryo.readClassAndObject(input);
+        final TreeMultimap<Comparable, Comparable> multimap = TreeMultimap.create(keyComparator, valueComparator);
         readMultimap(kryo, input, multimap);
         return multimap;
     }

--- a/src/test/java/de/javakaffee/kryoserializers/guava/ArrayTableSerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/guava/ArrayTableSerializerTest.java
@@ -1,0 +1,61 @@
+package de.javakaffee.kryoserializers.guava;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.google.common.collect.ArrayTable;
+import de.javakaffee.kryoserializers.KryoTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+
+public class ArrayTableSerializerTest extends TableSerializerTestBase {
+
+    private Kryo _kryo;
+
+    @BeforeTest
+    public void setUp() throws Exception {
+        _kryo = new Kryo();
+        _kryo.setRegistrationRequired(false);
+        ArrayTableSerializer.registerSerializers(_kryo);
+    }
+
+    @Test(dataProvider = "Google Guava tables (non empty)")
+    public void testTable(Object[] contents) {
+        Set rowKeys = new LinkedHashSet();
+        Set colKeys = new LinkedHashSet();
+        for (int index = 0; index < contents.length; ) {
+            rowKeys.add(contents[index++]);
+            colKeys.add(contents[index++]);
+            index++; // skip value
+        }
+
+        final ArrayTable<Object, Object, Object> table = ArrayTable.create(rowKeys, colKeys);
+        populateTable(table, contents);
+        final byte[] serialized = KryoTest.serialize(_kryo, table);
+        final ArrayTable<Object, Object, Object> deserialized = KryoTest.deserialize(_kryo, serialized, ArrayTable.class);
+        assertEquals(deserialized, table);
+    }
+
+    @Test(dataProvider = "Google Guava tables (non empty)")
+    public void testTableCopy(Object[] contents) {
+        Set rowKeys = new LinkedHashSet();
+        Set colKeys = new LinkedHashSet();
+        for (int index = 0; index < contents.length; ) {
+            rowKeys.add(contents[index++]);
+            colKeys.add(contents[index++]);
+            index++; // skip value
+        }
+
+        final ArrayTable<Object, Object, Object> table = ArrayTable.create(rowKeys, colKeys);
+        populateTable(table, contents);
+        ArrayTable<Object, Object, Object> copy = _kryo.copy(table);
+
+        assertNotSame(copy, table);
+        assertEquals(copy, table);
+    }
+
+}

--- a/src/test/java/de/javakaffee/kryoserializers/guava/HashBasedTableSerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/guava/HashBasedTableSerializerTest.java
@@ -1,0 +1,43 @@
+package de.javakaffee.kryoserializers.guava;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.google.common.collect.HashBasedTable;
+import de.javakaffee.kryoserializers.KryoTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+
+public class HashBasedTableSerializerTest extends TableSerializerTestBase {
+
+    private Kryo _kryo;
+
+    @BeforeTest
+    public void setUp() throws Exception {
+        _kryo = new Kryo();
+        _kryo.setRegistrationRequired(false);
+        HashBasedTableSerializer.registerSerializers(_kryo);
+    }
+
+    @Test(dataProvider = "Google Guava tables")
+    public void testTable(Object[] contents) {
+        final HashBasedTable<Object, Object, Object> table = HashBasedTable.create();
+        populateTable(table, contents);
+        final byte[] serialized = KryoTest.serialize(_kryo, table);
+        final HashBasedTable<Object, Object, Object> deserialized = KryoTest.deserialize(_kryo, serialized, HashBasedTable.class);
+        assertEquals(deserialized, table);
+    }
+
+    @Test(dataProvider = "Google Guava tables")
+    public void testTableCopy(Object[] contents) {
+        final HashBasedTable<Object, Object, Object> table = HashBasedTable.create();
+        populateTable(table, contents);
+
+        HashBasedTable<Object, Object, Object> copy = _kryo.copy(table);
+
+        assertNotSame(copy, table);
+        assertEquals(copy, table);
+    }
+
+}

--- a/src/test/java/de/javakaffee/kryoserializers/guava/ImmutableMapSerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/guava/ImmutableMapSerializerTest.java
@@ -2,15 +2,16 @@ package de.javakaffee.kryoserializers.guava;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.google.common.collect.ImmutableMap;
-import static org.testng.Assert.*;
-
+import com.google.common.collect.ImmutableTable;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.util.EnumMap;
+import java.util.Map;
 
 import static de.javakaffee.kryoserializers.KryoTest.deserialize;
 import static de.javakaffee.kryoserializers.KryoTest.serialize;
+import static org.testng.Assert.*;
 
 /**
  * Created by pmarcos on 29/06/15.
@@ -68,6 +69,38 @@ public class ImmutableMapSerializerTest {
         assertEquals(deserialized, immutableObj);
     }
 
+    @Test
+    public void testRowMap() {
+        ImmutableMap<Object, Map<Object, Object>> obj = getDenseImmutableTable().rowMap();
+        final byte[] serialized = serialize(_kryo, obj);
+        final ImmutableMap<?, ?> deserialized = deserialize(_kryo, serialized, ImmutableMap.class);
+        assertEquals(deserialized, obj);
+    }
+
+    @Test
+    public void testRow() {
+        Map<Object, Object> obj = getDenseImmutableTable().rowMap().get("a");
+        final byte[] serialized = serialize(_kryo, obj);
+        final ImmutableMap<?, ?> deserialized = deserialize(_kryo, serialized, ImmutableMap.class);
+        assertEquals(deserialized, obj);
+    }
+
+    @Test
+    public void testColumnMap() {
+        ImmutableMap<Object, Map<Object, Object>> obj = getDenseImmutableTable().columnMap();
+        final byte[] serialized = serialize(_kryo, obj);
+        final ImmutableMap<?, ?> deserialized = deserialize(_kryo, serialized, ImmutableMap.class);
+        assertEquals(deserialized, obj);
+    }
+
+    @Test
+    public void testColumn() {
+        Map<Object, Object> obj = getDenseImmutableTable().columnMap().get(1);
+        final byte[] serialized = serialize(_kryo, obj);
+        final ImmutableMap<?, ?> deserialized = deserialize(_kryo, serialized, ImmutableMap.class);
+        assertEquals(deserialized, obj);
+    }
+
     // Kryo#copy tests
 
     @Test
@@ -89,6 +122,41 @@ public class ImmutableMapSerializerTest {
         final ImmutableMap<?, ?> obj = ImmutableMap.of(1, 2, 3, 4);
         final ImmutableMap<?, ?> copied = _kryo.copy(obj);
         assertSame(copied, obj);
+    }
+
+    @Test
+    public void testCopyRowMap() {
+        final ImmutableMap<?, ?> obj = getDenseImmutableTable().rowMap();
+        final ImmutableMap<?, ?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+    @Test
+    public void testCopyRow() {
+        final Map<Object, Object> obj = getDenseImmutableTable().rowMap().get("a");
+        final Map<Object, Object> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+    @Test
+    public void testCopyColumnMap() {
+        final ImmutableMap<?, ?> obj = getDenseImmutableTable().columnMap();
+        final ImmutableMap<?, ?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+    @Test
+    public void testCopyColumn() {
+        final Map<Object, Object> obj = getDenseImmutableTable().columnMap().get(1);
+        final Map<Object, Object> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+    private ImmutableTable<Object, Object, Object> getDenseImmutableTable() {
+        return ImmutableTable.builder()
+                .put("a", 1, 1)
+                .put("b", 1, 1)
+                .build();
     }
 
 }

--- a/src/test/java/de/javakaffee/kryoserializers/guava/ImmutableTableSerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/guava/ImmutableTableSerializerTest.java
@@ -1,0 +1,96 @@
+package de.javakaffee.kryoserializers.guava;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.google.common.collect.ImmutableTable;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static de.javakaffee.kryoserializers.KryoTest.deserialize;
+import static de.javakaffee.kryoserializers.KryoTest.serialize;
+import static org.testng.Assert.*;
+
+public class ImmutableTableSerializerTest {
+
+    private Kryo _kryo;
+
+    @BeforeTest
+    public void setUp() throws Exception {
+        _kryo = new Kryo();
+
+        ImmutableTableSerializer.registerSerializers(_kryo);
+    }
+
+    @Test(enabled = true)
+    public void testEmpty() {
+        final ImmutableTable<?, ?, ?> obj = ImmutableTable.of();
+        final byte[] serialized = serialize(_kryo, obj);
+        final ImmutableTable<?, ?, ?> deserialized = deserialize(_kryo, serialized, ImmutableTable.class);
+        assertTrue(deserialized.isEmpty());
+        assertEquals(deserialized.size(), obj.size());
+    }
+
+    @Test(enabled = true)
+    public void testSingleton() {
+        final ImmutableTable<?, ?, ?> obj = ImmutableTable.of("a", 1, 2.3);
+        final byte[] serialized = serialize(_kryo, obj);
+        final ImmutableTable<?, ?, ?> deserialized = deserialize(_kryo, serialized, ImmutableTable.class);
+        assertEquals(deserialized, obj);
+    }
+
+    @Test(enabled = true)
+    public void testDense() {
+        final ImmutableTable<?, ?, ?> obj = ImmutableTable.builder()
+                .put("a", 1, 1)
+                .put("b", 1, 1)
+                .build();
+        final byte[] serialized = serialize(_kryo, obj);
+        final ImmutableTable<?, ?, ?> deserialized = deserialize(_kryo, serialized, ImmutableTable.class);
+        assertEquals(deserialized, obj);
+    }
+
+    @Test(enabled = true)
+    public void testSparse() {
+        final ImmutableTable<?, ?, ?> obj = ImmutableTable.builder()
+                .put("a", 1, 1)
+                .put("b", 2, 1)
+                .build();
+        final byte[] serialized = serialize(_kryo, obj);
+        final ImmutableTable<?, ?, ?> deserialized = deserialize(_kryo, serialized, ImmutableTable.class);
+        assertEquals(deserialized, obj);
+    }
+
+    @Test(enabled = true)
+    public void testCopyEmpty() {
+        final ImmutableTable<?, ?, ?> obj = ImmutableTable.of();
+        final ImmutableTable<?, ?, ?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+    @Test(enabled = true)
+    public void testCopySingleton() {
+        final ImmutableTable<?, ?, ?> obj = ImmutableTable.of("a", 1, 2.3);
+        final ImmutableTable<?, ?, ?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+    @Test(enabled = true)
+    public void testCopyDense() {
+        final ImmutableTable<?, ?, ?> obj = ImmutableTable.builder()
+                .put("a", 1, 1)
+                .put("b", 1, 1)
+                .build();
+        final ImmutableTable<?, ?, ?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+    @Test(enabled = true)
+    public void testCopySparse() {
+        final ImmutableTable<?, ?, ?> obj = ImmutableTable.builder()
+                .put("a", 1, 1)
+                .put("b", 2, 1)
+                .build();
+        final ImmutableTable<?, ?, ?> copied = _kryo.copy(obj);
+        assertSame(copied, obj);
+    }
+
+}

--- a/src/test/java/de/javakaffee/kryoserializers/guava/LinkedHashMultimapSerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/guava/LinkedHashMultimapSerializerTest.java
@@ -30,7 +30,7 @@ public class LinkedHashMultimapSerializerTest extends MultimapSerializerTestBase
 
     @Test(dataProvider = "Google Guava multimaps")
     public void testMultimapCopy(Object[] contents) {
-        final LinkedHashMultimap<Comparable, Comparable> multimap = LinkedHashMultimap.create().create();
+        final LinkedHashMultimap<Comparable, Comparable> multimap = LinkedHashMultimap.create();
         populateMultimap(multimap, contents);
 
         LinkedHashMultimap<Comparable, Comparable> copy = _kryo.copy(multimap);

--- a/src/test/java/de/javakaffee/kryoserializers/guava/TableSerializerTestBase.java
+++ b/src/test/java/de/javakaffee/kryoserializers/guava/TableSerializerTestBase.java
@@ -1,0 +1,47 @@
+package de.javakaffee.kryoserializers.guava;
+
+import com.google.common.collect.Table;
+import org.testng.annotations.DataProvider;
+
+public class TableSerializerTestBase {
+
+    @DataProvider(name = "Google Guava tables")
+    public Object[][][] getTables() {
+        final Object[][] tables = new Object[][]{
+                new Object[]{},
+                new Object[]{"foo", "bar", "baz"},
+                new Object[]{"new", Thread.State.NEW, 1, "run", Thread.State.RUNNABLE, 2},
+                new Object[]{'a', 1, 1, 'b', 2, 2, 'c', 3, 3, 'a', 4, 4, 'b', 5, 5},
+                new Object[]{'a', 1, 1, 'b', 2, 2, 'c', 3, 3, 'a', 4, 1, 'b', 5, 2}
+        };
+        final Object[][][] toProvide = new Object[tables.length][][];
+        int index = 0;
+        for (final Object[] table : tables) {
+            toProvide[index++] = new Object[][]{table};
+        }
+        return toProvide;
+    }
+
+    @DataProvider(name = "Google Guava tables (non empty)")
+    public Object[][][] getTablesNonEmpty() {
+        final Object[][] tables = new Object[][]{
+                new Object[]{"foo", "bar", "baz"},
+                new Object[]{"new", Thread.State.NEW, 1, "run", Thread.State.RUNNABLE, 2},
+                new Object[]{'a', 1, 1, 'b', 2, 2, 'c', 3, 3, 'a', 4, 4, 'b', 5, 5},
+                new Object[]{'a', 1, 1, 'b', 2, 2, 'c', 3, 3, 'a', 4, 1, 'b', 5, 2}
+        };
+        final Object[][][] toProvide = new Object[tables.length][][];
+        int index = 0;
+        for (final Object[] table : tables) {
+            toProvide[index++] = new Object[][]{table};
+        }
+        return toProvide;
+    }
+
+    public <R, C, V> void populateTable(Table<R, C, V> table, Object[] contents) {
+        for (int index = 0; index < contents.length; ) {
+            table.put((R) contents[index++], (C) contents[index++], (V) contents[index++]);
+        }
+    }
+
+}

--- a/src/test/java/de/javakaffee/kryoserializers/guava/TreeBasedTableSerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/guava/TreeBasedTableSerializerTest.java
@@ -1,0 +1,115 @@
+package de.javakaffee.kryoserializers.guava;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.TreeBasedTable;
+import de.javakaffee.kryoserializers.KryoTest;
+import de.javakaffee.kryoserializers.TestClasses;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+
+public class TreeBasedTableSerializerTest extends TableSerializerTestBase {
+
+    private Kryo _kryo;
+
+    @BeforeTest
+    public void setUp() throws Exception {
+        _kryo = new Kryo();
+        _kryo.setRegistrationRequired(false);
+        TreeBasedTableSerializer.registerSerializers(_kryo);
+    }
+
+    @Test(dataProvider = "Google Guava tables")
+    public void testTable(Object[] contents) {
+        final TreeBasedTable<Comparable, Comparable, Object> table = TreeBasedTable.create();
+        populateTable(table, contents);
+        final byte[] serialized = KryoTest.serialize(_kryo, table);
+        final TreeBasedTable<Comparable, Comparable, Object> deserialized = KryoTest.deserialize(_kryo, serialized, TreeBasedTable.class);
+        assertEquals(deserialized, table);
+    }
+
+    @Test(dataProvider = "Google Guava tables")
+    public void testTableCopy(Object[] contents) {
+        final TreeBasedTable<Comparable, Comparable, Object> table = TreeBasedTable.create();
+        populateTable(table, contents);
+
+        TreeBasedTable<Comparable, Comparable, Object> copy = _kryo.copy(table);
+
+        assertNotSame(copy, table);
+        assertEquals(copy, table);
+    }
+
+    @Test
+    public void testDifferentRowComparatorCopy() {
+        final TreeBasedTable<TestClasses.Person, String, String> table = TreeBasedTable.create(TreeBasedTableSerializerTest.CompareByAge.INSTANCE, Ordering.natural());
+
+        // Natural order: "Alice" < "Bob"; by age: "Bob" < "Alice"
+        table.put(TestClasses.createPerson("Alice", TestClasses.Person.Gender.FEMALE, 20), "foo", "bar");
+        table.put(TestClasses.createPerson("Bob", TestClasses.Person.Gender.MALE, 10), "bar", "baz");
+
+        TreeBasedTable<TestClasses.Person, String, String> copy = _kryo.copy(table);
+
+        assertNotSame(copy, table);
+        assertEquals(copy, table);
+    }
+
+    @Test
+    public void testDifferentRowComparatorSerialize() {
+        final TreeBasedTable<TestClasses.Person, String, String> table = TreeBasedTable.create(TreeBasedTableSerializerTest.CompareByAge.INSTANCE, Ordering.natural());
+
+        // Natural order: "Alice" < "Bob"; by age: "Bob" < "Alice"
+        table.put(TestClasses.createPerson("Alice", TestClasses.Person.Gender.FEMALE, 20), "foo", "bar");
+        table.put(TestClasses.createPerson("Bob", TestClasses.Person.Gender.MALE, 10), "bar", "baz");
+
+        final byte[] serialized = KryoTest.serialize(_kryo, table);
+        final TreeBasedTable<TestClasses.Person, String, String> deserialized = KryoTest.deserialize(_kryo, serialized, TreeBasedTable.class);
+
+        assertNotSame(deserialized, table);
+        assertEquals(deserialized, table);
+    }
+
+    @Test
+    public void testDifferentColumnComparatorCopy() {
+        final TreeBasedTable<String, TestClasses.Person, String> table = TreeBasedTable.create(Ordering.natural(), TreeBasedTableSerializerTest.CompareByAge.INSTANCE);
+
+        // Natural order: "Alice" < "Bob"; by age: "Bob" < "Alice"
+        table.put("foo", TestClasses.createPerson("Alice", TestClasses.Person.Gender.FEMALE, 20), "bar");
+        table.put("bar", TestClasses.createPerson("Bob", TestClasses.Person.Gender.MALE, 10), "baz");
+
+        TreeBasedTable<String, TestClasses.Person, String> copy = _kryo.copy(table);
+
+        assertNotSame(copy, table);
+        assertEquals(copy, table);
+    }
+
+    @Test
+    public void testDifferentColumnComparatorSerialize() {
+        final TreeBasedTable<String, TestClasses.Person, String> table = TreeBasedTable.create(Ordering.natural(), TreeBasedTableSerializerTest.CompareByAge.INSTANCE);
+
+        // Natural order: "Alice" < "Bob"; by age: "Bob" < "Alice"
+        table.put("foo", TestClasses.createPerson("Alice", TestClasses.Person.Gender.FEMALE, 20), "bar");
+        table.put("bar", TestClasses.createPerson("Bob", TestClasses.Person.Gender.MALE, 10), "baz");
+
+        final byte[] serialized = KryoTest.serialize(_kryo, table);
+        final TreeBasedTable<String, TestClasses.Person, String> deserialized = KryoTest.deserialize(_kryo, serialized, TreeBasedTable.class);
+
+        assertNotSame(deserialized, table);
+        assertEquals(deserialized, table);
+    }
+
+    private static class CompareByAge implements Comparator<TestClasses.Person> {
+        private static final TreeBasedTableSerializerTest.CompareByAge INSTANCE = new TreeBasedTableSerializerTest.CompareByAge();
+
+        @Override
+        public int compare(TestClasses.Person o1, TestClasses.Person o2) {
+            return o1.getAge().compareTo(o2.getAge());
+        }
+    }
+
+}

--- a/src/test/java/de/javakaffee/kryoserializers/guava/TreeMultimapSerializerTest.java
+++ b/src/test/java/de/javakaffee/kryoserializers/guava/TreeMultimapSerializerTest.java
@@ -1,7 +1,5 @@
 package de.javakaffee.kryoserializers.guava;
 
-import static org.testng.Assert.assertNotSame;
-
 import com.esotericsoftware.kryo.Kryo;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.TreeMultimap;
@@ -9,10 +7,13 @@ import de.javakaffee.kryoserializers.KryoTest;
 import de.javakaffee.kryoserializers.TestClasses;
 import de.javakaffee.kryoserializers.TestClasses.Person;
 import de.javakaffee.kryoserializers.TestClasses.Person.Gender;
-import java.io.Serializable;
-import java.util.Comparator;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import static org.testng.Assert.assertNotSame;
 
 public class TreeMultimapSerializerTest extends MultimapSerializerTestBase {
 
@@ -46,7 +47,7 @@ public class TreeMultimapSerializerTest extends MultimapSerializerTestBase {
     }
 
     @Test
-    public void testDifferentKeyComparator() {
+    public void testDifferentKeyComparatorCopy() {
         final TreeMultimap<TestClasses.Person, String> multimap = TreeMultimap.create(CompareByAge.INSTANCE, Ordering.natural());
 
         // Natural order: "Alice" < "Bob"; by age: "Bob" < "Alice"
@@ -60,11 +61,26 @@ public class TreeMultimapSerializerTest extends MultimapSerializerTestBase {
     }
 
     @Test
-    public void testDifferentValueComparator() {
+    public void testDifferentKeyComparatorSerialize() {
+        final TreeMultimap<TestClasses.Person, String> multimap = TreeMultimap.create(CompareByAge.INSTANCE, Ordering.natural());
+
+        // Natural order: "Alice" < "Bob"; by age: "Bob" < "Alice"
+        multimap.put(TestClasses.createPerson("Alice", Gender.FEMALE, 20), "foo");
+        multimap.put(TestClasses.createPerson("Bob", Gender.MALE, 10), "bar");
+
+        final byte[] serialized = KryoTest.serialize(_kryo, multimap);
+        final TreeMultimap<TestClasses.Person, String> deserialized = KryoTest.deserialize(_kryo, serialized, TreeMultimap.class);
+
+        assertNotSame(deserialized, multimap);
+        assertEqualMultimaps(true, true, deserialized, multimap);
+    }
+
+    @Test
+    public void testDifferentValueComparatorCopy() {
         final TreeMultimap<String, TestClasses.Person> multimap = TreeMultimap.create(Ordering.<String>natural(), CompareByAge.INSTANCE);
 
         // Natural order: "Alice" < "Bob"; by age: "Bob" < "Alice"
-        multimap.put("foo", TestClasses.createPerson("Alice", Gender.FEMALE , 20));
+        multimap.put("foo", TestClasses.createPerson("Alice", Gender.FEMALE, 20));
         multimap.put("bar", TestClasses.createPerson("Bob", Gender.MALE, 10));
 
         TreeMultimap<String, TestClasses.Person> copy = _kryo.copy(multimap);
@@ -73,13 +89,28 @@ public class TreeMultimapSerializerTest extends MultimapSerializerTestBase {
         assertEqualMultimaps(true, true, copy, multimap);
     }
 
+    @Test
+    public void testDifferentValueComparatorSerialize() {
+        final TreeMultimap<String, TestClasses.Person> multimap = TreeMultimap.create(Ordering.<String>natural(), CompareByAge.INSTANCE);
+
+        // Natural order: "Alice" < "Bob"; by age: "Bob" < "Alice"
+        multimap.put("foo", TestClasses.createPerson("Alice", Gender.FEMALE, 20));
+        multimap.put("bar", TestClasses.createPerson("Bob", Gender.MALE, 10));
+
+        final byte[] serialized = KryoTest.serialize(_kryo, multimap);
+        final TreeMultimap<String, TestClasses.Person> deserialized = KryoTest.deserialize(_kryo, serialized, TreeMultimap.class);
+
+        assertNotSame(deserialized, multimap);
+        assertEqualMultimaps(true, true, deserialized, multimap);
+    }
+
     private static class CompareByAge implements Comparator<Person>, Serializable {
         private static final CompareByAge INSTANCE = new CompareByAge();
         private static final long serialVersionUID = -6835503002691497297L;
 
         @Override
         public int compare(Person o1, Person o2) {
-          return o1.getAge().compareTo(o2.getAge());
+            return o1.getAge().compareTo(o2.getAge());
         }
     }
 }


### PR DESCRIPTION
**TL;DR;**

I noticed that the Guava's [Table](https://github.com/google/guava/wiki/NewCollectionTypesExplained#table) structure is not directly supported by this library. I need this in my project, so I decided to share my work.

**What's inside:**
- serializers for all guava's `Table` implementations, including: `ArrayTable`, `HashBasedTable`, `TreeBasedTable` and `ImmutableTable`
- a fix to `TreeMultimapSerializer` to include key and value comparators (this allows to serialize a `TreeMultimap` together with non-standard comparators)
- a fix to `ImmutableMapSerializer` to include some private implementations used by `DenseImmutableTable`

**Details**

So I'm using kryo-serializers + subzero + hazelcast + guava. I noticed I couldn't serialize the `ImmutableTable` properly so I decided to investigate why. Surprisingly some of the Table implementations are serialized just fine (e.g. `HashBasedTable`) but that is only because they are handled by the generic `FieldSerializer`, so their private fields are basically inferred and serialized. The reason why this doesn't work for `ImmutableTable` implementation is that it internally uses some private implementation of `ImmutableMap` (e.g. `Column` or `Row`) which in turn are serialized by the `FieldSerializer` as regular `Map`, and fail during deserialization. 

This PR fixes both sides of this problem: it adds direct support for `Table` implementations (including `ImmutableTable`) as well as registers additional private implementations of `ImmutableMap` with `ImmutableMapSerializer`.

Additionally I noticed that the `TreeMultimapSerializer` didn't cover non-default comparators. I added support for those in `TreeBasedTableSerializer`, so decided to fix it for `TreeMultimapSerializer` too. 

Please take a look and review before merging. I'll appreciate any feedback!