### PR TITLE
Handle BitSet serialization using long arrays

### DIFF
--- a/src/main/java/de/javakaffee/kryoserializers/BitSetSerializer.java
+++ b/src/main/java/de/javakaffee/kryoserializers/BitSetSerializer.java
@@ -11,34 +11,19 @@ public class BitSetSerializer extends Serializer<BitSet> {
 
     @Override
     public BitSet copy(final Kryo kryo, final BitSet original) {
-        final BitSet result = new BitSet();
-        final int length = original.length();
-        for(int i = 0; i < length; i++) {
-            result.set(i, original.get(i));
-        }
-        return result;
+        return BitSet.valueOf(original.toLongArray());
     }
 
     @Override
     public void write(final Kryo kryo, final Output output, final BitSet bitSet) {
-        final int len = bitSet.length();
-
-        output.writeInt(len, true);
-
-        for(int i = 0; i < len; i++) {
-            output.writeBoolean(bitSet.get(i));
-        }
+        final long[] longs = bitSet.toLongArray();
+        output.writeInt(longs.length, true);
+        output.writeLongs(longs);
     }
 
     @Override
     public BitSet read(final Kryo kryo, final Input input, final Class<? extends BitSet> bitSetClass) {
         final int len = input.readInt(true);
-        final BitSet ret = new BitSet(len);
-
-        for(int i = 0; i < len; i++) {
-            ret.set(i, input.readBoolean());
-        }
-
-        return ret;
+        return BitSet.valueOf(input.readLongs(len));
     }
 }


### PR DESCRIPTION
For any bitset with more than 8 bits, using longs to serialize the BitSet will be more space efficient. In either case, the BitSet operations using long arrays is faster.